### PR TITLE
darwin: full support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 package-lock.json
 
+# pnpm
+pnpm-lock.yaml
+
 # gluon
 build
 chrome_data

--- a/src/browser/firefox.js
+++ b/src/browser/firefox.js
@@ -18,6 +18,7 @@ user_pref('privacy.window.maxInnerHeight', ${windowSize[1]});`}
 user_pref('privacy.resistFingerprinting', true);
 user_pref('fission.bfcacheInParent', false);
 user_pref('fission.webContentIsolationStrategy', 0);
+${process.platform === 'darwin' ? `user_pref('browser.tabs.inTitlebar', 0);` : `` }
 `);
 
 // user_pref('privacy.resistFingerprinting', false);

--- a/src/browser/firefox.js
+++ b/src/browser/firefox.js
@@ -18,6 +18,7 @@ user_pref('privacy.window.maxInnerHeight', ${windowSize[1]});`}
 user_pref('privacy.resistFingerprinting', true);
 user_pref('fission.bfcacheInParent', false);
 user_pref('fission.webContentIsolationStrategy', 0);
+user_pref('ui.key.menuAccessKeyFocuses', false);
 ${process.platform === 'darwin' ? `user_pref('browser.tabs.inTitlebar', 0);` : `` }
 `);
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,12 @@ const browserPaths = ({
 
     firefox: 'firefox',
     firefox_nightly: 'firefox-nightly'
+  },
+
+  darwin: {
+    chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    edge: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    firefox: '/Applications/Firefox.app/Contents/MacOS/firefox',
   }
 })[process.platform];
 


### PR DESCRIPTION
Mostly works, but has several bugs relating to both Chromium and Firefox.
I only have Edge and Firefox on my system, but have included the path for Chrome on the assumption it follows a similar file structure to Edge.

- [ ] Fix Chromium-based browsers opening a new window in Gluon's data dir when clicking dock icon (seems out of scope)
- [x] Fix Firefox being able to open other browser pages from menu bar (may be multi-platform issue?)
- [x] Verify support