### PR TITLE
feat: windows user preferred & installed browsers

### DIFF
--- a/src/browser/windows.js
+++ b/src/browser/windows.js
@@ -1,0 +1,64 @@
+import { exec as _e } from 'node:child_process'
+import { promisify } from 'node:util'
+import { join, basename } from 'node:path'
+
+const REG_PATH = (process.platform === 'win32') ? join(process.env.windir, 'system32', 'reg.exe') : 'REG'
+const ITEM_PATTERN = /^\s*([^\s]*)\s*(REG_SZ|REG_MULTI_SZ|REG_EXPAND_SZ|REG_DWORD|REG_QWORD|REG_BINARY|REG_NONE)[^\S\r\n]*(.*)$/gm
+const FOLDER_PATTERN = /^(HKEY_.*)[^\S\r\n]*$/gm
+const INTERNET_CLIENTS_PATH = '\\SOFTWARE\\Clients\\StartMenuInternet'
+const DEFAULT_KEY = '(Default)'
+
+const exec = promisify(_e)
+
+async function query (path) {
+  // exec can throw error, but this should be caught outside of this function
+  const out = await getRegOutput(path)
+  const items = {}
+  for (let match = ITEM_PATTERN.exec(out); match; match = ITEM_PATTERN.exec(out)) {
+    if (match.index === ITEM_PATTERN.lastIndex) ITEM_PATTERN.lastIndex++
+    const [_, name, type, data] = match
+    items[name] = { type, data }
+  }
+  return items
+}
+
+async function list (path) {
+  const values = await getRegOutput(path + ' /v ""')
+  // we only want to list folders so we exclude values
+  // this can probably be done via regex, but this is simpler
+  const entries = (await getRegOutput(path)).replace(values, '')
+  return entries.match(FOLDER_PATTERN)
+}
+
+async function getRegOutput (cmd) {
+  const { stdout, stderr } = await exec(REG_PATH + ' query ' + cmd, { cwd: undefined, env: process.env })
+  if (stderr) throw stderr
+  return stdout
+}
+
+async function getProgIdPath (progID) {
+  const items = await query(`HKCR\\${progID}\\shell\\open\\command`)
+  const defaultItem = items[DEFAULT_KEY]
+  if (!defaultItem) return null
+  const defaultPath = defaultItem.data.slice(1)
+  return defaultPath.slice(0, defaultPath.indexOf('"'))
+}
+
+export async function getUserPreferred () {
+  const userPreferred = await query('HKCU\\SOFTWARE\\Microsoft\\Windows\\Shell\\Associations\\URLAssociations\\https\\UserChoice')
+  return getProgIdPath(userPreferred.ProgID.data)
+}
+
+export async function getInstalledBrowsers () {
+  const machineClients = await list('HKLM' + INTERNET_CLIENTS_PATH)
+  const userClients = await list('HKCU' + INTERNET_CLIENTS_PATH)
+  const browsers = {}
+  // should this be batched?
+  // user clients should overwrite machine clients
+  for (const path of [...machineClients, ...userClients]) {
+    try {
+      browsers[basename(path)] = (await query(path + '\\shell\\open\\command'))[DEFAULT_KEY]?.data.slice(1, -1)
+    } catch (e) {}
+  }
+  return browsers
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'url';
 
 import Chromium from './browser/chromium.js';
 import Firefox from './browser/firefox.js';
+import { getUserPreferred } from './browser/windows.js';
 
 import IdleAPI from './api/idle.js';
 import ControlsAPI from './api/controls.js';
@@ -68,6 +69,13 @@ const getBrowserPath = async browser => {
 
 const findBrowserPath = async (forceBrowser) => {
   if (forceBrowser) return [ await getBrowserPath(forceBrowser), forceBrowser ];
+
+  if (process.platform === 'win32') {
+    try {
+      const userPreferred = await getUserPreferred()
+      if (userPreferred) return userPreferred
+    } catch (e) {}
+  }
 
   for (const x in browserPaths) {
     if (process.argv.includes('--' + x) || process.argv.includes('--' + x.split('_')[0])) return [ await getBrowserPath(x), x ];


### PR DESCRIPTION
This PR implements __USER__ not system preferred browsers as a single computer might have multiple accounts with different preferences, it also implements a list of all installed browsers, which would be nice to use for stuff like engine preference, where the developer could define a preferred engine like chromium or gecko and we could try to find that browser in those installed ones.

Windows only

Known issues:
getInstalledBrowsers will return html editors like vscode, vsstudio, jetbrains, notepad and notepad++

notably this repository doesn't have an eslint config defined, so I didn't know what coding styles to follow.

addresses #11 

I do not believe however that checking by .html is a good idea, imho checking by https is a way better idea, but @CanadaHonk proposed .html files