### PR TITLE
Add support new browsers Mac OS

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -10,6 +10,7 @@
 ## v0.9.0
 - [X] Browser version info API
 - [X] Idle API v2
+- [X] Support darwin (Mac OS)
 - [ ] Window show/hide API
 
 ## v0.8.0

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,13 @@ const browserPaths = ({
 
   darwin: {
     chrome: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    chrome_canary: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
     edge: '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+
+    chromium: '/Applications/Chromium.app/Contents/MacOS/Chromium',
+
     firefox: '/Applications/Firefox.app/Contents/MacOS/firefox',
+    firefox_nightly: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox'
   }
 })[process.platform];
 


### PR DESCRIPTION
Added darwin support for the following browsers:

- Chrome canary
- Chromium
- Firefox nightly

<img width="854" alt="Screenshot 2023-01-03 at 11 45 36" src="https://user-images.githubusercontent.com/47431914/210305778-60b91a75-0189-4a35-bc1d-35457414e746.png">
<img width="903" alt="Screenshot 2023-01-03 at 11 49 16" src="https://user-images.githubusercontent.com/47431914/210305784-79e35a86-9c1c-49b9-8c24-942878ab3af4.png">