### PR TITLE
Added `.DS_Store` in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# miscellaneous
+.DS_Store
+
 # node
 node_modules
 package-lock.json
@@ -8,4 +11,3 @@ pnpm-lock.yaml
 # gluon
 build
 chrome_data
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pnpm-lock.yaml
 # gluon
 build
 chrome_data
+.DS_Store


### PR DESCRIPTION
I was checking out gluon on macOS and found out that `.DS_Store` is not in the .gitignore file 

Use case of .DS_Store file:

> In the Apple macOS operating system, .DS_Store is a file that stores custom attributes of its containing folder, such as folder view options, icon positions, and other visual information.
[Source: Wikipedia](https://en.wikipedia.org/wiki/.DS_Store)

So I added it in .gitignore file to let macOS developer not upload useless file while adding/fixing anything in this repository by mistake.