### PR TITLE
typedef: properly set default value for useSessionId

### DIFF
--- a/gluon.d.ts
+++ b/gluon.d.ts
@@ -116,8 +116,9 @@ type CDPApi = {
     /** Parameters of CDP command. */
     params?: Object,
 
-    /** Send session ID with the command (default true). */
-    useSessionId?: Boolean = true
+    /** Send session ID with the command (default true).
+    @defaultValue true */
+    useSessionId?: boolean
   ): Promise<any>
 };
 

--- a/gluon.d.ts
+++ b/gluon.d.ts
@@ -117,7 +117,7 @@ type CDPApi = {
     params?: Object,
 
     /** Send session ID with the command (default true).
-    @defaultValue true */
+    @default true */
     useSessionId?: boolean
   ): Promise<any>
 };


### PR DESCRIPTION
https://tsdoc.org/pages/tags/defaultvalue/
If this is not applied, tsc fails with these errors:
```
node_modules/.pnpm/github.com+gluon-framework+gluon@b589fb3e8c7c39bd77961dec8c04f61f35850761/node_modules/@gluon-framework/gluon/gluon.d.ts:120:5 - error TS1015: Parameter cannot have question mark and initializer.

120     useSessionId?: Boolean = true
        ~~~~~~~~~~~~

node_modules/.pnpm/github.com+gluon-framework+gluon@b589fb3e8c7c39bd77961dec8c04f61f35850761/node_modules/@gluon-framework/gluon/gluon.d.ts:120:5 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

120     useSessionId?: Boolean = true
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: node_modules/.pnpm/github.com+gluon-framework+gluon@b589fb3e8c7c39bd77961dec8c04f61f35850761/node_modules/@gluon-framework/gluon/gluon.d.ts:120
```