### PR TITLE
add widevine installation

### DIFF
--- a/gluon.d.ts
+++ b/gluon.d.ts
@@ -249,6 +249,12 @@ type OpenOptions = {
 
   /** Force Gluon to use a specific browser engine instead of automatically finding a browser itself. */
   forceEngine?: BrowserEngine
+
+  /** 
+   * Ask Gluon to provide Widevine to the browser.
+   * @default true
+   */
+  widevine?: boolean,
 };
 
 /**
@@ -261,3 +267,19 @@ export function open(
   /** Additional options for opening. */
   options: OpenOptions
 ): Promise<Window>;
+
+type EnsureWidevineOptions = {
+  /** Force Gluon to use a specific browser instead of automatically finding one itself. */
+  forceBrowser?: Browser;
+
+  /** Force Gluon to use a specific browser engine instead of automatically finding a browser itself. */
+  forceEngine?: BrowserEngine;
+};
+
+/**
+ * Ensures that Widevine is installed for the relevant browser.
+ * If it is not, installs it.
+ */
+export function ensureWidevine(
+  options: EnsureWidevineOptions
+): Promise<void>;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/gluon-framework/gluon#readme",
   "type": "module",
   "dependencies": {
+    "unzipper": "^0.10.11",
     "ws": "^8.11.0"
   }
 }

--- a/src/launcher/widevine.js
+++ b/src/launcher/widevine.js
@@ -1,0 +1,133 @@
+// massive shoutouts to https://github.com/proprietary/chromium-widevine/
+
+import { resolve } from "path";
+import { existsSync, createReadStream } from "fs";
+import { rm, mkdir, writeFile, cp } from "fs/promises";
+import { platform, arch, tmpdir } from "os";
+import { Extract } from "unzipper";
+
+const tempDirectory = resolve(tmpdir(), "gluon-widevine");
+
+const checkWidevine = (dataFolder) =>
+  existsSync(resolve(dataFolder, "WidevineCdm"));
+
+async function installWidevine(dataFolder) {
+  await rm(tempDirectory, { recursive: true, force: true });
+  await mkdir(tempDirectory);
+
+  const cpuArch = arch();
+
+  if (["x64", "ia32", "arm64"].indexOf(cpuArch) === -1) return;
+
+  const plat =
+    {
+      win32: "win",
+      darwin: "mac",
+    }[platform()] ?? "linux";
+
+  const versions = (
+    await (
+      await fetch("https://dl.google.com/widevine-cdm/versions.txt")
+    ).text()
+  ).split("\n");
+  const latest = versions[versions.length - 2];
+
+  const release = await (
+    await fetch(
+      `https://dl.google.com/widevine-cdm/${latest}-${plat}-${cpuArch}.zip`
+    )
+  ).arrayBuffer();
+
+  const wvZipPath = resolve(tempDirectory, "widevine.zip");
+  const wvUnzippedPath = resolve(tempDirectory, "widevine");
+  const wvFixedPath = resolve(tempDirectory, "widevine_fixed");
+
+  await writeFile(wvZipPath, new Uint8Array(release));
+
+  await new Promise((res) =>
+    createReadStream(wvZipPath).pipe(
+      Extract({ path: wvUnzippedPath }).on("close", res)
+    )
+  );
+
+  await mkdir(wvFixedPath);
+
+  const files = [["LICENSE.txt", "LICENSE"], ["manifest.json"]];
+
+  switch (plat) {
+    case "linux":
+      files.push([
+        "libwidevinecdm.so",
+        `_platform_specific/linux_${cpuArch}/libwidevinecdm.so`,
+      ]);
+      break;
+    case "mac":
+      files.push(
+        [
+          "libwidevinecdm.dylib",
+          `_platform_specific/mac_${cpuArch}/libwidevinecdm.dylib`,
+        ],
+        [
+          "libwidevinecdm.dylib.sig",
+          `_platform_specific/mac_${cpuArch}/libwidevinecdm.dylib.sig`,
+        ]
+      );
+      break;
+    case "win":
+      files.push(
+        [
+          "libwidevinecdm.dll",
+          `_platform_specific/win_${cpuArch}/libwidevinecdm.dll`,
+        ],
+        [
+          "libwidevinecdm.dll.lib",
+          `_platform_specific/win_${cpuArch}/libwidevinecdm.dll.lib`,
+        ],
+        [
+          "libwidevinecdm.dll.sig",
+          `_platform_specific/win_${cpuArch}/libwidevinecdm.dll.sig`,
+        ]
+      );
+      break;
+  }
+
+  for (const [from, to] of files)
+    await cp(resolve(wvUnzippedPath, from), resolve(wvFixedPath, to ?? from), {
+      recursive: true,
+    });
+
+  const wvChromeLocation = resolve(dataFolder, `WidevineCdm/${latest}`);
+  await cp(resolve(wvFixedPath), wvChromeLocation, { recursive: true });
+
+  await writeFile(
+    resolve(dataFolder, "WidevineCdm/latest-component-updated-widevine-cdm"),
+    JSON.stringify({
+      Path: wvChromeLocation,
+    })
+  );
+
+  log("Widevine installed successfully!");
+}
+
+async function ensureWidevineUnmutexed(dataFolder) {
+  try {
+    if (checkWidevine(dataFolder)) return;
+
+    await installWidevine(dataFolder);
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+// we only really want to run one widevine install at once
+// no matter how many browser windows you open
+let currentlyInstallingPromise;
+
+export async function ensureWidevine(dataFolder) {
+  try {
+    currentlyInstallingPromise ??= ensureWidevineUnmutexed(dataFolder);
+    await currentlyInstallingPromise;
+  } finally {
+    currentlyInstallingPromise = undefined;
+  }
+}


### PR DESCRIPTION
This PR adds Widevine installation to Chromium environments in Gluon.

It will install it if needed for any Chromium browser window.

If opted out with `{widevine: false}`, it will not.

It also exports `await Gluon.ensureWidevine({forceBrowser, forceEngine})`,
to explicitly install it.

Tested platforms:
 - [x] Linux x64
 - [ ] Linux x86 
 - [ ] macOS x64
 - [ ] macOS arm64
 - [ ] Windows x64
 - [ ] Windows x86
 - [ ] Windows arm64

Also note: if the default should be changed to false, index.js:190:86