### PR TITLE
chore: import version directly from `package.json`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 const rgb = (r, g, b, msg) => `\x1b[38;2;${r};${g};${b}m${msg}\x1b[0m`;
 global.log = (...args) => console.log(`[${rgb(88, 101, 242, 'Gluon')}]`, ...args);
 
-process.versions.gluon = '0.12.0-alpha.0';
+import pkgJSON from '../package.json'
+
+process.versions.gluon = pkgJSON.version;
 
 import { join, dirname, delimiter, sep, resolve, isAbsolute } from 'path';
 import { access, readdir } from 'fs/promises';


### PR DESCRIPTION
Get version info from a single source instead of setting it manually.