### PR TITLE
Mention Bun branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Gluon
 - **Tiny bundle sizes** - <1MB using system Node, <10MB when bundling it
 - **Chromium *and Firefox* supported as browser engine**, unlike any other active framework
 - **Minimal and easy to use** - Gluon has a simple yet powerful API to make apps with a Node backend
-- **Also supports Deno** (experimental) - Deno is also being worked as an option (developer choice) in replacement of NodeJS for the backend, [check out the `deno` branch](https://github.com/gluon-framework/gluon/tree/deno)
-- **Also supports Bun** (experimental) - Bun is also being worked as an option (developer choice) in replacement of NodeJS for the backend, [check out the `bun` branch](https://github.com/gluon-framework/gluon/tree/bun)
+- **Deno and Bun support** (experimental) - Support for Deno and Bun are being worked on as alternatives to NodeJS for the backend (developer choice), [see the `deno` branch](https://github.com/gluon-framework/gluon/tree/deno) and [the `bun` branch](https://github.com/gluon-framework/gluon/tree/bun)
 - **Fast build times** - Gluon has build times under 1 second on most machines for small projects
 - **Actively developed** and **listening to feedback** - new updates are coming around weekly, quickly adding unplanned requested features if liked by the community (like Firefox support!)
 - **Cross-platform** - Gluon works on Windows, Linux, and macOS (WIP)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Gluon
 - **Chromium *and Firefox* supported as browser engine**, unlike any other active framework
 - **Minimal and easy to use** - Gluon has a simple yet powerful API to make apps with a Node backend
 - **Also supports Deno** (experimental) - Deno is also being worked as an option (developer choice) in replacement of NodeJS for the backend, [check out the `deno` branch](https://github.com/gluon-framework/gluon/tree/deno)
+- **Also supports Bun** (experimental) - Bun is also being worked as an option (developer choice) in replacement of NodeJS for the backend, [check out the `bun` branch](https://github.com/gluon-framework/gluon/tree/bun)
 - **Fast build times** - Gluon has build times under 1 second on most machines for small projects
 - **Actively developed** and **listening to feedback** - new updates are coming around weekly, quickly adding unplanned requested features if liked by the community (like Firefox support!)
 - **Cross-platform** - Gluon works on Windows, Linux, and macOS (WIP)


### PR DESCRIPTION
I've been looking far and wide for a way to write desktop apps using Bun instead of Node or Deno as the backend (because the app I'm working on has performance as a mission-critical feature). Still may end up going the Tauri route with Rust, but having to learn Rust is a pain. 

The fact that Gluon is working on a Bun implementation (even if it's still experimental) is a huge draw. Mentioning it in the README is a no brainer!

I copied the wording/structure to match that of the Deno mention, as this seemed most logical.